### PR TITLE
Refactor dox analysis

### DIFF
--- a/api/srv/invoice-assessment-service.cds
+++ b/api/srv/invoice-assessment-service.cds
@@ -64,7 +64,7 @@ service InvoiceAssessmentService {
     function getFileFromS3(s3BucketKey : String)                                                      returns LargeString;
     function getPositionsFromDOX(id : String)                                                         returns String;
     function getLineItemsFromDOX(id : String)                                                         returns String;
-    function areInvoiceExtractionsCompleted()                                                         returns String;
+    function areInvoiceExtractionsCompleted()                                                         returns array of String;
 
 
     type ReturnMessage {

--- a/api/srv/invoice-assessment-service.cds
+++ b/api/srv/invoice-assessment-service.cds
@@ -95,5 +95,5 @@ service InvoiceAssessmentService {
     action   uploadToDOXToGetPositions(id : String)                                                   returns String;
     action   uploadToDOXToGetLineItems(id : String)                                                   returns String;
     action   deleteFileFromS3(s3BucketKey : String, documentId : String)                              returns ReturnMessage;
-    action   checkAllDocumentsExtractions()                                                           returns String;
+    action   doxExtractFromInvoices();
 }

--- a/api/srv/invoice-assessment-service.cds
+++ b/api/srv/invoice-assessment-service.cds
@@ -64,7 +64,7 @@ service InvoiceAssessmentService {
     function getFileFromS3(s3BucketKey : String)                                                      returns LargeString;
     function getPositionsFromDOX(id : String)                                                         returns String;
     function getLineItemsFromDOX(id : String)                                                         returns String;
-    function areInvoiceExtractionsCompleted()                                                         returns array of String;
+    function areInvoiceExtractionsCompleted()                                                         returns { done: array of String; pending: array of String; };
 
 
     type ReturnMessage {

--- a/api/srv/invoice-assessment-service.cds
+++ b/api/srv/invoice-assessment-service.cds
@@ -65,6 +65,9 @@ service InvoiceAssessmentService {
     function getPositionsFromDOX(id : String)                                                         returns String;
     function getLineItemsFromDOX(id : String)                                                         returns String;
     function areInvoiceExtractionsCompleted()                                                         returns { done: array of String; pending: array of String; };
+    // returns json of dox response, no good type for that unfortunately
+    // says String, but still returns json
+    function doxGetPositions(invoiceID: String)                                                       returns String;
 
 
     type ReturnMessage {

--- a/api/srv/invoice-assessment-service.cds
+++ b/api/srv/invoice-assessment-service.cds
@@ -68,7 +68,7 @@ service InvoiceAssessmentService {
     // returns json of dox response, no good type for that unfortunately
     // says String, but still returns json
     function doxGetPositions(invoiceID: String)                                                       returns String;
-
+    function doxGetLineItems(invoiceID: String)                                                       returns String;
 
     type ReturnMessage {
         message : String;

--- a/api/srv/invoice-assessment-service.ts
+++ b/api/srv/invoice-assessment-service.ts
@@ -528,10 +528,11 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         return { storedInvoices: storedInvoices, waitingFor: waitingFor };
     };
 
-    /* Returns ids of invoices which dox has analysed already */
+    /* Returns ids of invoices which dox has (not) analysed */
     private areInvoiceExtractionsCompleted = async () => {
         const invs = await SELECT.from(Invoices).columns(`{ invoiceID, doxPositionsJobID }`);
-        return invs.filter((inv) => !!inv.doxPositionsJobID).map((inv) => inv.invoiceID);
+        const done = invs.filter((inv) => !!inv.doxPositionsJobID).map((inv) => inv.invoiceID);
+        return { done, pending: invs.map((inv) => inv.invoiceID).filter((ID) => !done.includes(ID)) };
     };
 
     // easy cache by storing the results in a file on the server

--- a/api/srv/invoice-assessment-service.ts
+++ b/api/srv/invoice-assessment-service.ts
@@ -102,6 +102,7 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         this.on("getFileFromS3", (req: Request) => this.getFileFromS3(req.data.s3BucketKey as string));
         this.on("areInvoiceExtractionsCompleted", this.areInvoiceExtractionsCompleted);
         this.on("doxGetPositions", this.doxGetPositions);
+        this.on("doxGetLineItems", this.doxGetLineItems);
 
         // ACTIONS
         this.on("setCV", this.setCV);
@@ -419,7 +420,12 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         return resp.extraction.lineItems.map((item: any) => item[0]);
     };
 
-    // private doxGetLineItems = async () => {}
+    private doxGetLineItems = async (req: Request) => {
+        const ID = req.data.invoiceID as string;
+        const jobID = (await SELECT.one.from(Invoices, ID).columns(`{ doxLineItemsJobID }`)).doxLineItemsJobID;
+        const resp = await (await this.getDoxConnection()).send("GET", "/document/jobs/" + jobID);
+        return resp.extraction.lineItems;
+    };
 
     private doxCreatePositionsSchema = async () => {
         const schema = {

--- a/api/srv/invoice-assessment-service.ts
+++ b/api/srv/invoice-assessment-service.ts
@@ -98,9 +98,7 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         this.on("getUserInfo", this.getUserInfo);
         this.on("getPdfBytesByInvoiceID", this.getPdfBytesByInvoiceID);
         this.on("getPdfBytesByKey", this.getPdfBytesByKey);
-        this.on("getPositionsFromDOX", this.getPositionsFromDOX);
         this.on("getFileFromS3", (req: Request) => this.getFileFromS3(req.data.s3BucketKey as string));
-        this.on("getLineItemsFromDOX", this.getLineItemsFromDOX);
         this.on("areInvoiceExtractionsCompleted", this.areInvoiceExtractionsCompleted);
 
         // ACTIONS
@@ -108,10 +106,8 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         this.on("acceptOrRejectInvoice", this.acceptOrRejectInvoice);
         this.on("assignProjectRole", this.assignProjectRole);
         this.on("uploadFileToS3", this.uploadFileToS3);
-        this.on("uploadToDOXToGetPositions", this.uploadToDOXToGetPositions);
-        this.on("uploadToDOXToGetLineItems", this.uploadToDOXToGetLineItems);
         this.on("deleteFileFromS3", this.deleteFileFromS3);
-        this.on("checkAllDocumentsExtractions", this.checkAllDocumentsExtractions);
+        this.on("doxExtractFromInvoices", this.doxExtractFromInvoices);
 
         this.after(["CREATE", "UPDATE"], "Deductions", this.recordLatestDeduction);
         this.after(["CREATE", "UPDATE"], "Retentions", this.recordLatestRetention);
@@ -141,55 +137,6 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
             isAdmin: req.user.is("admin"),
             projectRoles: projectRoles
         };
-    };
-
-    private getDoxSchemaForPositionExtraction = async () => {
-        const doxConnection = await this.getDoxConnection();
-        const doxSchemas = (await doxConnection.send("GET", "/schemas?clientId=default")).schemas;
-        return doxSchemas.filter((schema: any) => schema.name === "invoicePositions");
-    };
-
-    private isDoxSchemaExisting = async () => {
-        return (await this.getDoxSchemaForPositionExtraction()).length > 0;
-    };
-
-    private createDoxSchema = async () => {
-        if (await this.isDoxSchemaExisting()) return;
-        const doxConnection = await this.getDoxConnection();
-        const schema = {
-            clientId: "default",
-            name: "invoicePositions",
-            schemaDescription: "Schema to extract the positions of an invoice",
-            documentType: "custom",
-            documentTypeDescription: ""
-        };
-        const doxResponse: any = await doxConnection.send("POST", "/schemas", schema);
-        const schemaId = doxResponse.id;
-        const payloadToAddPositionLineItem: { headerFields: []; lineItemFields: {}[] } = {
-            headerFields: [],
-            lineItemFields: [
-                {
-                    name: "position",
-                    label: "",
-                    description:
-                        "first column in invoice table. Might need two lines as its column is quite narrow. Examples for positions are 01.01. . .0030 or 02. . . . If after position, there is no description for this position, the position belongs to the last position.",
-                    defaultExtractor: {},
-                    predefined: false,
-                    setupType: "static",
-                    setupTypeVersion: "2.0.0",
-                    setup: { type: "auto", priority: 1 },
-                    formattingType: "string",
-                    formatting: {},
-                    formattingTypeVersion: "1.0.0"
-                }
-            ]
-        };
-        await doxConnection.send(
-            "POST",
-            "/schemas/" + schemaId + "/versions/1/fields?clientId=default",
-            payloadToAddPositionLineItem
-        );
-        await doxConnection.send("POST", "/schemas/" + schemaId + "/versions/1/activate?clientId=default");
     };
 
     /* Set current validator of invoice */
@@ -405,177 +352,50 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         });
     };
 
-    private async getDoxConnection(): Promise<Service> {
-        return await cds.connect.to(DOX_DESTINATION_PREMIUM);
-    }
+    /* INTERACTION WITH DOX */
 
-    private uploadInvoicesWithoutJobIDToDOX = async (invoices: any[]) => {
-        const invoicesWithoutJobIDs = invoices.filter(
-            (invoice) => !invoice.doxPositionsJobID || !invoice.doxLineItemsJobID
+    /* Entry point to extract line items from invoices (pdfs). Note, we need one extra schema
+    just for positions because default invoice schema doesn't include them.
+    We store dox job ids alongside invoice and use it as indicator that extraction is complete */
+    private doxExtractFromInvoices = async () => {
+        const todos = (await SELECT.from(Invoices).columns(`{ invoiceID, doxPositionsJobID }`)) // todos, the invoices not yet analyzed
+            .filter((inv) => !inv.doxPositionsJobID)
+            .map((inv) => inv.invoiceID);
+        if (todos.length === 0) return;
+        // initial sample invoice '3420987413543' not analyzed yet -> no dox schema for positions yet either
+        if (todos.find((ID) => ID === "3420987413543")) await this.doxCreatePositionsSchema();
+
+        // prettiere-ignore
+        const jobs = await Promise.all(
+            todos
+                .map((invoiceID) => [
+                    this.doxUploadInvoice(invoiceID, "invoicePositions"),
+                    this.doxUploadInvoice(invoiceID)
+                ])
+                .flat()
         );
-        // sample invoice '3420987413543' not analyzed yet -> probably no dox schema yet either
-        if (invoicesWithoutJobIDs.map((invoice) => invoice.invoiceID).includes("3420987413543")) {
-            await this.createDoxSchema();
-        }
-        for (const invoiceWithoutJobID of invoicesWithoutJobIDs) {
-            const data = { data: { id: invoiceWithoutJobID.invoiceID } };
-            const positionsJobID = await this.uploadToDOXToGetPositions(data);
-            const lineItemsJobID = await this.uploadToDOXToGetLineItems(data);
-            invoices.forEach((invoice) => {
-                if (invoice.invoiceID == invoiceWithoutJobID.invoiceID) {
-                    invoice.doxPositionsJobID = positionsJobID;
-                    invoice.doxLineItemsJobID = lineItemsJobID;
-                }
-            });
-        }
+        // prettier-ignore
+        await Promise.all(todos.map( async (ID, i) =>
+                            // @ts-ignore
+                            await UPDATE(Invoices, ID).with({ doxPositionsJobID: jobs[i * 2].id, doxLineItemsJobID: jobs[i * 2 + 1].id })));
     };
 
-    private cacheDOXResultsInS3 = async (invoiceID: string, extractionType: string, extraction: string) => {
-        const s3Client = this.getS3Client();
-        const key = invoiceID + extractionType + ".json";
-        const buffer = Buffer.from(extraction);
-
-        const command = new PutObjectCommand({ Bucket: BUCKET_S3, Body: buffer, Key: key });
-        await s3Client.send(command);
-        return;
-    };
-
-    private getDOXResultsFromS3 = async (invoiceID: string, extractionType: string) => {
-        const key = invoiceID + extractionType + ".json";
-        const s3Client = this.getS3Client();
-        const command = new GetObjectCommand({ Bucket: BUCKET_S3, Key: key });
-        const response = await s3Client.send(command);
-        const body = await response.Body.transformToString("utf-8");
-        return body;
-    };
-
-    private checkDocumentExtractionStatusInterval: NodeJS.Timeout = null;
-
-    private checkDocumentExtractionStatusIntervalCallback = async (invoice: any, intervalTimeout: any) => {
-        const doxLineItems = await this.getLineItemsOfInvoice(invoice.invoiceID);
-        const doxPositions = await this.getPositionsOfInvoice(invoice.invoiceID);
-        if (!doxPositions.status && !doxLineItems.status) {
-            await this.cacheDOXResultsInS3(invoice.invoiceID, "lineItems", JSON.stringify(doxLineItems.lineItems));
-            await this.cacheDOXResultsInS3(invoice.invoiceID, "positions", JSON.stringify(doxPositions.positions));
-            this.currentlyCheckingDocumentExtractions--;
-            clearInterval(this.checkDocumentExtractionStatusInterval);
-            return;
-        }
-        if (intervalTimeout < Date.now()) {
-            this.currentlyCheckingDocumentExtractions--;
-            clearInterval(this.checkDocumentExtractionStatusInterval);
-            return;
-        }
-    };
-
-    private checkAllDocumentsExtractionsBackgroundJob = () => {
-        cds.spawn({}, async () => {
-            const invoices: { invoiceID?: string; doxPositionsJobID?: string; doxLineItemsJobID?: string }[] =
-                await SELECT.from(Invoices).columns(`{ invoiceID, doxPositionsJobID, doxLineItemsJobID }`);
-            await this.uploadInvoicesWithoutJobIDToDOX(invoices);
-            this.currentlyCheckingDocumentExtractions--;
-            for (const invoice of invoices) {
-                this.currentlyCheckingDocumentExtractions++;
-                if (
-                    (await this.getStoredPositionsForInvoice(invoice.invoiceID)) &&
-                    (await this.getStoredLineItemsForInvoice(invoice.invoiceID))
-                ) {
-                    this.currentlyCheckingDocumentExtractions--;
-                    continue;
-                }
-                const doxPositions = await this.getPositionsOfInvoice(invoice.invoiceID);
-                const doxLineItems = await this.getLineItemsOfInvoice(invoice.invoiceID);
-                if (!doxPositions.status && !doxLineItems.status) {
-                    await this.cacheDOXResultsInS3(
-                        invoice.invoiceID,
-                        "lineItems",
-                        JSON.stringify(doxLineItems.lineItems)
-                    );
-                    await this.cacheDOXResultsInS3(
-                        invoice.invoiceID,
-                        "positions",
-                        JSON.stringify(doxPositions.positions)
-                    );
-                    this.currentlyCheckingDocumentExtractions--;
-                    continue;
-                }
-                const intervalTimeout = Date.now() + 1000 * 60 * 3;
-                this.checkDocumentExtractionStatusInterval = setInterval(
-                    () => this.checkDocumentExtractionStatusIntervalCallback(invoice, intervalTimeout),
-                    10000
-                );
-            }
-        });
-    };
-
-    private currentlyCheckingDocumentExtractions = 0;
-    private checkAllDocumentsExtractions = async () => {
-        if (this.currentlyCheckingDocumentExtractions != 0) return;
-        this.currentlyCheckingDocumentExtractions++;
-        this.checkAllDocumentsExtractionsBackgroundJob();
-        const invoices: { invoiceID?: string; doxPositionsJobID?: string; doxLineItemsJobID?: string }[] =
-            await SELECT.from(Invoices).columns(`{ invoiceID, doxPositionsJobID, doxLineItemsJobID }`);
-        const storedInvoices: string[] = invoices
-            .filter(
-                async (invoice) =>
-                    (await this.getStoredPositionsForInvoice(invoice.invoiceID)) &&
-                    (await this.getStoredLineItemsForInvoice(invoice.invoiceID))
-            )
-            .map((invoice) => invoice.invoiceID);
-        const waitingFor: string[] = invoices
-            .filter((invoice) => !storedInvoices.includes(invoice.invoiceID))
-            .map((invoice) => invoice.invoiceID);
-        return { storedInvoices: storedInvoices, waitingFor: waitingFor };
-    };
-
-    /* Returns ids of invoices which dox has (not) analysed */
-    private areInvoiceExtractionsCompleted = async () => {
-        const invs = await SELECT.from(Invoices).columns(`{ invoiceID, doxPositionsJobID }`);
-        const done = invs.filter((inv) => !!inv.doxPositionsJobID).map((inv) => inv.invoiceID);
-        return { done, pending: invs.map((inv) => inv.invoiceID).filter((ID) => !done.includes(ID)) };
-    };
-
-    // easy cache by storing the results in a file on the server
-    private getStoredPositionsForInvoice = async (invoiceID: string) => {
-        let fileContent;
-        try {
-            fileContent = await this.getDOXResultsFromS3(invoiceID, "positions");
-        } catch (err) {}
-        if (fileContent) return JSON.parse(fileContent.toString());
-        return null;
-    };
-
-    private getPositionsOfInvoice = async (invoiceID: string) => {
-        const storedJobID = (
-            await SELECT.from(Invoices).columns(`{ doxPositionsJobID }`).where({ invoiceID: invoiceID })
-        )[0].doxPositionsJobID;
-        if (!storedJobID) throw new Error("No stored job ID found for invoice " + invoiceID);
-
-        const storedPositions = await this.getStoredPositionsForInvoice(invoiceID);
-        if (storedPositions) return { positions: storedPositions, storedLoad: true };
-
-        const path = "/document/jobs/" + storedJobID;
-
+    /* Upload invoice first for dox to extract from it */
+    private doxUploadInvoice = async (invoiceID: string, schemaName?: string) => {
+        const form = await this.doxFormData(
+            invoiceID,
+            {
+                clientId: "default",
+                schemaName: schemaName ?? "SAP_invoice_schema",
+                documentType: schemaName ? "custom" : "invoice"
+            },
+            schemaName ? invoiceID + "-Positions.pdf" : invoiceID + "-LineItems.pdf"
+        );
         const doxConnection = await this.getDoxConnection();
-        const json = await doxConnection.send("GET", path);
-
-        if (json.status == "PENDING") return { status: "PENDING" };
-        return { positions: json, storedLoad: false };
+        return await doxConnection.send("POST", "/document/jobs", form.getBuffer(), form.getHeaders());
     };
 
-    private getPositionsFromDOX = async (req: Request) => {
-        const { data } = req;
-        const invoiceID: string = data.id;
-        const json = await this.getPositionsOfInvoice(invoiceID);
-
-        return JSON.stringify(this.mapLineItemsToPositions(json.positions.extraction.lineItems));
-    };
-
-    private mapLineItemsToPositions(lineItems: any) {
-        return lineItems.map((lineItemsOfLine: any) => lineItemsOfLine[0]);
-    }
-
-    private async getFormDataForDOXUpload(invoiceID: string, DOX_OPTIONS: object, pdfName: string): Promise<FormData> {
+    private async doxFormData(invoiceID: string, DOX_OPTIONS: object, pdfName: string): Promise<FormData> {
         const formData = new FormData();
         const pdfFile = await this.getPDFById(invoiceID);
         const pdfByteArray = await pdfFile.transformToByteArray();
@@ -585,100 +405,55 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         return formData;
     }
 
-    private currentlyUploadingDocumentForPositions: { [invoiceID: string]: boolean } = {};
-    private uploadToDOXToGetPositions = async (req: Request | { data: { id: string } }) => {
-        const { data } = req;
-        const invoiceID: string = data.id;
-        if (this.currentlyUploadingDocumentForPositions[invoiceID]) return;
-        this.currentlyUploadingDocumentForPositions[invoiceID] = true;
-        const storedJobID = (
-            await SELECT.from(Invoices).columns(`{ doxPositionsJobID }`).where({ invoiceID: invoiceID })
-        )[0].doxPositionsJobID;
-        if (storedJobID && storedJobID != "") return storedJobID;
+    /* Returns ids of invoices which dox has (not) analysed */
+    private areInvoiceExtractionsCompleted = async () => {
+        const invs = await SELECT.from(Invoices).columns(`{ invoiceID, doxPositionsJobID }`);
+        const done = invs.filter((inv) => !!inv.doxPositionsJobID).map((inv) => inv.invoiceID);
+        return { done, pending: invs.map((inv) => inv.invoiceID).filter((ID) => !done.includes(ID)) };
+    };
 
-        const pdfName: string = invoiceID + "-Positions.pdf";
-        const path = "/document/jobs";
-        const DOX_OPTIONS = {
+    private doxCreatePositionsSchema = async () => {
+        const schema = {
             clientId: "default",
             documentType: "custom",
-            schemaId: (await this.getDoxSchemaForPositionExtraction())[0].id,
-            enrichtment: {}
+            name: "invoicePositions",
+            schemaDescription: "Schema to extract the positions of an invoice",
+            documentTypeDescription: "" // is required
         };
-
-        const formData = await this.getFormDataForDOXUpload(invoiceID, DOX_OPTIONS, pdfName);
-
         const doxConnection = await this.getDoxConnection();
+        const doxResponse: any = await doxConnection.send("POST", "/schemas", schema);
+        const schemaId = doxResponse.id;
 
-        const json = await doxConnection.send("POST", path, formData.getBuffer(), formData.getHeaders());
-
-        const jobID = json.id;
-        await UPDATE(Invoices, invoiceID).with({ doxPositionsJobID: jobID });
-        this.currentlyUploadingDocumentForPositions[invoiceID] = false;
-        return jobID;
-    };
-
-    // easy cache by storing the results in a file on the server
-    private getStoredLineItemsForInvoice = async (invoiceID: string) => {
-        let fileContent;
-        try {
-            fileContent = await this.getDOXResultsFromS3(invoiceID, "lineItems");
-        } catch (err) {}
-        if (fileContent) return JSON.parse(fileContent.toString());
-        return null;
-    };
-
-    private getLineItemsOfInvoice = async (invoiceID: string): Promise<any> => {
-        const storedLineItems = await this.getStoredLineItemsForInvoice(invoiceID);
-        if (storedLineItems) return { lineItems: storedLineItems, storedLoad: true };
-        const storedJobID = (
-            await SELECT.from(Invoices).columns(`{ doxLineItemsJobID }`).where({ invoiceID: invoiceID })
-        )[0].doxLineItemsJobID;
-
-        const path = "/document/jobs/" + storedJobID;
-
-        const doxConnection = await this.getDoxConnection();
-        const json = await doxConnection.send("GET", path);
-
-        if (json.status == "PENDING") return { status: "PENDING" };
-        return { lineItems: json, storedLoad: false };
-    };
-
-    private getLineItemsFromDOX = async (req: Request) => {
-        const { data } = req;
-        const invoiceID: string = data.id;
-        const json = await this.getLineItemsOfInvoice(invoiceID);
-        return JSON.stringify(json.lineItems.extraction.lineItems);
-    };
-
-    private currentlyUploadingDocumentForLineItems: { [invoiceID: string]: boolean } = {};
-    private uploadToDOXToGetLineItems = async (req: Request | { data: { id: string } }) => {
-        const { data } = req;
-        const invoiceID: string = data.id;
-        if (this.currentlyUploadingDocumentForLineItems[invoiceID]) return;
-        this.currentlyUploadingDocumentForLineItems[invoiceID] = true;
-        const storedJobID = (
-            await SELECT.from(Invoices).columns(`{ doxLineItemsJobID }`).where({ invoiceID: invoiceID })
-        )[0].doxLineItemsJobID;
-        if (storedJobID && storedJobID != "") return storedJobID;
-
-        const pdfName: string = invoiceID + "-LineItems.pdf";
-        const path = "/document/jobs";
-        const DOX_OPTIONS = {
-            clientId: "default",
-            documentType: "invoice",
-            extraction: { lineItemFields: ["description", "netAmount", "quantity", "unitPrice", "unitOfMeasure"] }
+        const payloadToAddPositionLineItem: { headerFields: []; lineItemFields: {}[] } = {
+            headerFields: [],
+            lineItemFields: [
+                {
+                    name: "position",
+                    label: "",
+                    description:
+                        "first column in invoice table. Might need two lines as its column is quite narrow. Examples for positions are 01.01. . .0030 or 02. . . . If after position, there is no description for this position, the position belongs to the last position.",
+                    defaultExtractor: {},
+                    predefined: false,
+                    setupType: "static",
+                    setupTypeVersion: "2.0.0",
+                    setup: { type: "auto", priority: 1 },
+                    formattingType: "string",
+                    formatting: {},
+                    formattingTypeVersion: "1.0.0"
+                }
+            ]
         };
-
-        const formData = await this.getFormDataForDOXUpload(invoiceID, DOX_OPTIONS, pdfName);
-
-        const doxConnection = await this.getDoxConnection();
-        const json = await doxConnection.send("POST", path, formData.getBuffer(), formData.getHeaders());
-
-        const jobID = json.id;
-        await UPDATE(Invoices, invoiceID).with({ doxLineItemsJobID: jobID });
-        this.currentlyUploadingDocumentForLineItems[invoiceID] = false;
-        return jobID;
+        await doxConnection.send(
+            "POST",
+            "/schemas/" + schemaId + "/versions/1/fields?clientId=default",
+            payloadToAddPositionLineItem
+        );
+        await doxConnection.send("POST", "/schemas/" + schemaId + "/versions/1/activate?clientId=default");
     };
+
+    private getDoxConnection = () => cds.connect.to(DOX_DESTINATION_PREMIUM);
+
+    /* ------------------------------------------ */
 
     /* Track previous versions of a deduction, including the latest one */
     private recordLatestDeduction = async (results: any) => {
@@ -705,8 +480,6 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
         ]);
     };
 
-    /* HELPERS */
-
     private getNextFlowStatus = (roleNewCV: Roles) => {
         switch (roleNewCV) {
             case Roles.EXTERNAL_VALIDATOR:
@@ -717,30 +490,4 @@ export class InvoiceAssessmentService extends cds.ApplicationService {
                 return "";
         }
     };
-}
-
-interface Item {
-    name: string;
-    category: string;
-    value: string;
-    rawValue: string;
-    type: string;
-    page: number;
-    confidence: number;
-    coordinates: Coordinates;
-    label: string;
-    index?: number;
-}
-
-interface Coordinates {
-    x: number;
-    y: number;
-}
-
-interface InputObject {
-    lineItems: Item[][];
-}
-
-interface OutputObject {
-    lineItems: Item[];
 }

--- a/ui/src/pages/invoice-details/extract-pdf-data/PDFLineItems.ts
+++ b/ui/src/pages/invoice-details/extract-pdf-data/PDFLineItems.ts
@@ -34,18 +34,15 @@ export class PDFLineItems {
         this.id = id;
     }
 
-    // fetch new version of dox:
-    // figure out how to use destinations in code
-
     private async fetchLineItemsFromDOX(): Promise<any> {
-        return await fetch(`${BASE_URL_CAP}/getLineItemsFromDOX(id='${this.id}')`);
+        return await fetch(`${BASE_URL_CAP}/doxGetLineItems(invoiceID='${this.id}')`);
     }
 
     private async getInvoiceEntries() {
         const doxServiceResponse = await this.fetchLineItemsFromDOX();
         if (doxServiceResponse.ok) {
             const doxServiceResponseJson = await doxServiceResponse.json();
-            const lineItems = JSON.parse(doxServiceResponseJson.value);
+            const lineItems = doxServiceResponseJson.value;
             return lineItems;
         } else throw new Error("Fetching DOX Service for LineItems failed with documentID " + this.id);
     }

--- a/ui/src/pages/invoice-details/extract-pdf-data/PDFPositions.ts
+++ b/ui/src/pages/invoice-details/extract-pdf-data/PDFPositions.ts
@@ -32,11 +32,11 @@ export class PDFPositions {
     }
 
     private async fetchPositionsFromDOX() {
-        const positionsResponse = await fetch(`${BASE_URL_CAP}/getPositionsFromDOX(id='${this.id}')`, {
+        const positionsResponse = await fetch(`${BASE_URL_CAP}/doxGetPositions(invoiceID='${this.id}')`, {
             method: "GET",
             headers: new Headers({ "content-type": "application/json" })
         });
-        const positions = JSON.parse((await positionsResponse.json()).value);
+        const positions = (await positionsResponse.json()).value;
         return positions;
     }
 

--- a/ui/src/pages/invoices-index/InvoicesIndex.tsx
+++ b/ui/src/pages/invoices-index/InvoicesIndex.tsx
@@ -1,12 +1,51 @@
 import { useEffect, useState, useContext } from "react";
-import { Page } from "@ui5/webcomponents-react";
+import { Page, MessageBox } from "@ui5/webcomponents-react";
 
 import { Invoices } from "@entities";
 import InvoicesTables from "./InvoicesTables";
 import { UserContext } from "@/contexts/UserContext";
+import { BASE_URL_CAP } from "@/constants";
+
+let bgJob: number; // id of background job that checks if dox is done
 
 export default function InvoicesIndex() {
     const [invoices, setInvoices] = useState<Invoices>([]);
+    const [showMessage, setShowMessage] = useState(false);
+    const [extractionState, setExtractionState] = useState<{ [invoiceID: string]: boolean }>({});
+
+    const { isCV } = useContext(UserContext);
+    // @ts-ignore
+    const assignedInvoices = invoices.filter((invoice) => isCV(invoice.CV_user_ID as string));
+    // @ts-ignore
+    const otherInvoices = invoices.filter((invoice) => !isCV(invoice.CV_user_ID as string));
+
+    useEffect(() => {
+        fetchAllInvoices().catch(console.log);
+        updateExtractionState();
+    }, []);
+
+    async function updateExtractionState() {
+        const vals = Object.values(extractionState);
+        if (bgJob && vals.every((done) => done) && vals.length > 0) {
+            console.log("everything done, clearing interval now");
+            window.clearInterval(bgJob);
+            return;
+        }
+        console.log("api call now, checking extraction state now");
+        const resp = await fetch(`${BASE_URL_CAP}/areInvoiceExtractionsCompleted()`);
+        if (resp.ok) {
+            const data = await resp.json();
+            // let user kick of line items extraction from missing invoices using dox
+            if (data.pending.length > 0) setShowMessage(true);
+
+            const state: { [invoiceID: string]: boolean } = {};
+            for (const ID of data.done) state[ID] = true;
+            for (const ID of data.pending) state[ID] = false;
+            console.log("setting state now, state is", state, "data is", data);
+            setExtractionState(state);
+        }
+    }
+
     async function fetchAllInvoices() {
         const response = await fetch("/api/odata/v4/invoice-assessment/Invoices?$expand=project,statuses,CV");
         if (response.ok) {
@@ -17,19 +56,28 @@ export default function InvoicesIndex() {
         }
     }
 
-    const { isCV } = useContext(UserContext);
-    // @ts-ignore
-    const assignedInvoices = invoices.filter((invoice) => isCV(invoice.CV_user_ID as string));
-    // @ts-ignore
-    const otherInvoices = invoices.filter((invoice) => !isCV(invoice.CV_user_ID as string));
-
-    useEffect(() => {
-        fetchAllInvoices().catch(console.log);
-    }, []);
-
+    // TODO: translate content of msg
     return (
-        <Page disableScrolling style={{ paddingTop: "1rem", paddingBottom: "1rem" }}>
-            <InvoicesTables assignedInvoices={assignedInvoices} otherInvoices={otherInvoices} />
-        </Page>
+        <>
+            <Page disableScrolling style={{ paddingTop: "1rem", paddingBottom: "1rem" }}>
+                <InvoicesTables
+                    assignedInvoices={assignedInvoices}
+                    otherInvoices={otherInvoices}
+                    extractionState={extractionState}
+                />
+            </Page>
+            <MessageBox
+                type="Information"
+                open={showMessage}
+                onClose={() => {
+                    // prettier-ignore
+                    fetch(`${BASE_URL_CAP}/doxExtractFromInvoices`, { method: "POST", headers: { "content-type": "application/json" } })
+                        .then(() => { if (!bgJob) bgJob = window.setInterval(updateExtractionState, 10000); });
+                    setShowMessage(false);
+                }}
+            >
+                The line items of some invoices still need to be extracted. This will only take a moment.
+            </MessageBox>
+        </>
     );
 }

--- a/ui/src/pages/invoices-index/InvoicesTables.tsx
+++ b/ui/src/pages/invoices-index/InvoicesTables.tsx
@@ -18,9 +18,7 @@ export default function InvoicesTables({
     const [extractionState, setExtractionState] = useState<{ [key: string]: boolean }>({});
 
     useEffect(() => {
-        uploadAndFetchAllDocuments()
-            .then(() => checkExtractionStatusesOfAllInvoices().catch(console.log))
-            .catch(console.log);
+        checkExtractionStatusesOfAllInvoices();
     }, []);
 
     const uploadAndFetchAllDocuments = async () =>
@@ -31,11 +29,14 @@ export default function InvoicesTables({
         });
 
     async function checkExtractionStatusesOfAllInvoices() {
-        const res = await (await fetch(`${BASE_URL_CAP}/areInvoiceExtractionsCompleted()`, { method: "GET" })).json();
-        if (Object.values(res.value).includes(false)) {
-            setTimeout(() => checkExtractionStatusesOfAllInvoices(), 5000);
+        const resp = await fetch(`${BASE_URL_CAP}/areInvoiceExtractionsCompleted()`);
+        if (resp.ok) {
+            const data = await resp.json();
+            const state: { [invoiceID: string]: boolean } = {};
+            for (const ID of data.done) state[ID] = true;
+            for (const ID of data.pending) state[ID] = false;
+            setExtractionState(state);
         }
-        setExtractionState(res.value);
     }
 
     return (

--- a/ui/src/pages/invoices-index/InvoicesTables.tsx
+++ b/ui/src/pages/invoices-index/InvoicesTables.tsx
@@ -3,52 +3,18 @@ import { spacing } from "@ui5/webcomponents-react-base";
 import "@ui5/webcomponents-icons/dist/alert.js";
 
 import { Invoices } from "@entities";
-import { useEffect, useState } from "react";
 import Surface from "@/custom/Surface";
-import { BASE_URL_CAP } from "@/constants";
 import InvoicesTable from "./InvoicesTable";
-
-let bgJob: number; // id of background job that checks if dox is done
 
 export default function InvoicesTables({
     assignedInvoices,
-    otherInvoices
+    otherInvoices,
+    extractionState
 }: {
     assignedInvoices: Invoices;
     otherInvoices: Invoices;
+    extractionState: { [invoiceID: string]: boolean };
 }) {
-    const [extractionState, setExtractionState] = useState<{ [key: string]: boolean }>({});
-
-    useEffect(() => {
-        doxExtract(); // just fire and forget, endpoint checks if invoices need to be analyzed
-        checkExtractionStatusesOfAllInvoices().then(() => {
-            // React calls effect two times at dev time, make sure job is started once
-            if (!bgJob) bgJob = window.setInterval(checkExtractionStatusesOfAllInvoices, 10000);
-        });
-    }, []);
-
-    const doxExtract = () => {
-        return fetch(`${BASE_URL_CAP}/doxExtractFromInvoices`, {
-            method: "POST",
-            headers: { "content-type": "application/json" }
-        });
-    };
-
-    async function checkExtractionStatusesOfAllInvoices() {
-        if (bgJob && Object.values(extractionState).every((done) => done)) {
-            window.clearInterval(bgJob);
-            return;
-        }
-        const resp = await fetch(`${BASE_URL_CAP}/areInvoiceExtractionsCompleted()`);
-        if (resp.ok) {
-            const data = await resp.json();
-            const state: { [invoiceID: string]: boolean } = {};
-            for (const ID of data.done) state[ID] = true;
-            for (const ID of data.pending) state[ID] = false;
-            setExtractionState(state);
-        }
-    }
-
     return (
         <Surface>
             <InvoicesTable


### PR DESCRIPTION
- **simple GET endpoint to see extraction state**
- **cater towards what frontend already wants**
- **rewrite entry point to kick of dox analysis; simplify/delete things**
- **readd GET endpoint to get extracted positions from dox**
- **readd GET endpoint to get extracted line items from dox**
- **GET extraction state repeatedly again until we know dox is done**
- **let user kick of extraction of missing invoices with dox**
- **query actual status (done/pending) of dox jobs, don't just rely on there being job ids**
- **background job starting and stopping as expected now**
